### PR TITLE
Fix boolean BufferStruct prop

### DIFF
--- a/browser-tests/BufferStruct.test.ts
+++ b/browser-tests/BufferStruct.test.ts
@@ -34,9 +34,10 @@ describe('BufferStruct', function () {
 
     it('sub-class initial state', () => {
       expect(TestBufferStruct.staticInitialized).to.equal(true);
-      expect(TestBufferStruct.size).to.equal(1072);
+      expect(TestBufferStruct.size).to.equal(1084);
       expect(TestBufferStruct.typeId).to.equal(genTypeId('TEST'));
       expect(TestBufferStruct.typeIdStr).to.equal('TEST');
+      console.log(TestBufferStruct.propDefs);
       expect(TestBufferStruct.propDefs).to.deep.equal([
         {
           propNum: 0,
@@ -56,26 +57,42 @@ describe('BufferStruct', function () {
         },
         {
           propNum: 2,
-          name: 'numProp2',
-          type: 'number',
+          name: 'booleanProp1',
+          type: 'boolean',
           byteOffset: 552,
-          offset: 69,
-          byteSize: 8,
+          offset: 138,
+          byteSize: 4,
         },
         {
           propNum: 3,
+          name: 'numProp2',
+          type: 'number',
+          byteOffset: 560,
+          offset: 70,
+          byteSize: 8,
+        },
+        {
+          propNum: 4,
           name: 'stringProp2',
           type: 'string',
-          byteOffset: 560,
-          offset: 280,
+          byteOffset: 568,
+          offset: 284,
           byteSize: 512,
+        },
+        {
+          propNum: 5,
+          name: 'booleanProp2',
+          type: 'boolean',
+          byteOffset: 1080,
+          offset: 270,
+          byteSize: 4,
         },
       ]);
     });
 
     it('extended sub-class initial state', () => {
       expect(ExtTestBufferStruct.staticInitialized).to.equal(true);
-      expect(ExtTestBufferStruct.size).to.equal(1592);
+      expect(ExtTestBufferStruct.size).to.equal(1608);
       expect(ExtTestBufferStruct.typeId).to.equal(genTypeId('EXTT'));
       expect(ExtTestBufferStruct.typeIdStr).to.equal('EXTT');
       expect(ExtTestBufferStruct.propDefs).to.deep.equal([
@@ -97,34 +114,58 @@ describe('BufferStruct', function () {
         },
         {
           propNum: 2,
-          name: 'numProp2',
-          type: 'number',
+          name: 'booleanProp1',
+          type: 'boolean',
           byteOffset: 552,
-          offset: 69,
-          byteSize: 8,
+          offset: 138,
+          byteSize: 4,
         },
         {
           propNum: 3,
-          name: 'stringProp2',
-          type: 'string',
-          byteOffset: 560,
-          offset: 280,
-          byteSize: 512,
-        },
-        {
-          propNum: 4,
-          name: 'extNumProp1',
+          name: 'numProp2',
           type: 'number',
-          byteOffset: 1072,
-          offset: 134,
+          byteOffset: 560,
+          offset: 70,
           byteSize: 8,
         },
         {
+          propNum: 4,
+          name: 'stringProp2',
+          type: 'string',
+          byteOffset: 568,
+          offset: 284,
+          byteSize: 512,
+        },
+        {
           propNum: 5,
+          name: 'booleanProp2',
+          type: 'boolean',
+          byteOffset: 1080,
+          offset: 270,
+          byteSize: 4,
+        },
+        {
+          propNum: 6,
+          name: 'extBooleanProp1',
+          type: 'boolean',
+          byteOffset: 1084,
+          offset: 271,
+          byteSize: 4,
+        },
+        {
+          propNum: 7,
+          name: 'extNumProp1',
+          type: 'number',
+          byteOffset: 1088,
+          offset: 136,
+          byteSize: 8,
+        },
+        {
+          propNum: 8,
           name: 'extStringProp1',
           type: 'string',
-          byteOffset: 1080,
-          offset: 540,
+          byteOffset: 1096,
+          offset: 548,
           byteSize: 512,
         },
       ]);
@@ -187,14 +228,16 @@ describe('BufferStruct', function () {
       it('should create and use a new SharedArrayBuffer of the proper size if not passed in', () => {
         const bufferStruct = new TestBufferStruct();
         expect(bufferStruct.buffer).to.be.instanceOf(SharedArrayBuffer);
-        expect(bufferStruct.buffer.byteLength).to.equal(TestBufferStruct.size);
+        expect(bufferStruct.buffer.byteLength).to.equal(
+          Math.ceil(TestBufferStruct.size / 8) * 8,
+        );
       });
 
       it('should create and use a new SharedArrayBuffer of the proper size if not passed in (extended)', () => {
         const bufferStruct = new ExtTestBufferStruct();
         expect(bufferStruct.buffer).to.be.instanceOf(SharedArrayBuffer);
         expect(bufferStruct.buffer.byteLength).to.equal(
-          ExtTestBufferStruct.size,
+          Math.ceil(ExtTestBufferStruct.size / 8) * 8,
         );
       });
 
@@ -302,6 +345,36 @@ describe('BufferStruct', function () {
         expect(bufferStruct.extNumProp1).to.equal(0);
       });
 
+      it('should set and get values boolean properties', () => {
+        const bufferStruct = new TestBufferStruct();
+        // Boolean
+        bufferStruct.booleanProp1 = true;
+        bufferStruct.booleanProp2 = false;
+        expect(bufferStruct.booleanProp1).to.equal(true);
+        expect(bufferStruct.booleanProp2).to.equal(false);
+        bufferStruct.booleanProp1 = false;
+        bufferStruct.booleanProp2 = true;
+        expect(bufferStruct.booleanProp1).to.equal(false);
+        expect(bufferStruct.booleanProp2).to.equal(true);
+      });
+
+      it('should set and get values boolean properties (extended)', () => {
+        const bufferStruct = new ExtTestBufferStruct();
+        // Boolean
+        bufferStruct.booleanProp1 = false;
+        bufferStruct.booleanProp2 = true;
+        bufferStruct.extBooleanProp1 = false;
+        expect(bufferStruct.booleanProp1).to.equal(false);
+        expect(bufferStruct.booleanProp2).to.equal(true);
+        expect(bufferStruct.extBooleanProp1).to.equal(false);
+        bufferStruct.booleanProp1 = true;
+        bufferStruct.booleanProp2 = false;
+        bufferStruct.extBooleanProp1 = true;
+        expect(bufferStruct.booleanProp1).to.equal(true);
+        expect(bufferStruct.booleanProp2).to.equal(false);
+        expect(bufferStruct.extBooleanProp1).to.equal(true);
+      });
+
       it('should set and get values string properties', () => {
         const bufferStruct = new TestBufferStruct();
         // String
@@ -370,31 +443,10 @@ describe('BufferStruct', function () {
         expect(bufferStruct.isDirty()).to.equal(false);
         expect(bufferStruct.isDirty(0)).to.equal(false); // numProp1
         expect(bufferStruct.isDirty(1)).to.equal(false); // stringProp1
-        expect(bufferStruct.isDirty(2)).to.equal(false); // numProp2
-        expect(bufferStruct.isDirty(3)).to.equal(false); // stringProp2
-        bufferStruct.numProp1 = 123;
-        expect(bufferStruct.isDirty()).to.equal(true);
-        expect(bufferStruct.isDirty(0)).to.equal(true);
-        expect(bufferStruct.isDirty(1)).to.equal(false);
-        expect(bufferStruct.isDirty(2)).to.equal(false);
-        expect(bufferStruct.isDirty(3)).to.equal(false);
-        bufferStruct.stringProp1 = 'abc';
-        expect(bufferStruct.isDirty()).to.equal(true);
-        expect(bufferStruct.isDirty(0)).to.equal(true);
-        expect(bufferStruct.isDirty(1)).to.equal(true);
-        expect(bufferStruct.isDirty(2)).to.equal(false);
-        expect(bufferStruct.isDirty(3)).to.equal(false);
-      });
-
-      it('isDirty() should indicate if any or a specific property was changed (extended)', () => {
-        const bufferStruct = new ExtTestBufferStruct();
-        expect(bufferStruct.isDirty()).to.equal(false);
-        expect(bufferStruct.isDirty(0)).to.equal(false); // numProp1
-        expect(bufferStruct.isDirty(1)).to.equal(false); // stringProp1
-        expect(bufferStruct.isDirty(2)).to.equal(false); // numProp2
-        expect(bufferStruct.isDirty(3)).to.equal(false); // stringProp2
-        expect(bufferStruct.isDirty(4)).to.equal(false); // extNumProp1
-        expect(bufferStruct.isDirty(5)).to.equal(false); // extStringProp1
+        expect(bufferStruct.isDirty(2)).to.equal(false); // booleanProp1
+        expect(bufferStruct.isDirty(3)).to.equal(false); // numProp2
+        expect(bufferStruct.isDirty(4)).to.equal(false); // stringProp2
+        expect(bufferStruct.isDirty(5)).to.equal(false); // booleanProp2
         bufferStruct.numProp1 = 123;
         expect(bufferStruct.isDirty()).to.equal(true);
         expect(bufferStruct.isDirty(0)).to.equal(true);
@@ -403,6 +455,39 @@ describe('BufferStruct', function () {
         expect(bufferStruct.isDirty(3)).to.equal(false);
         expect(bufferStruct.isDirty(4)).to.equal(false);
         expect(bufferStruct.isDirty(5)).to.equal(false);
+        bufferStruct.stringProp1 = 'abc';
+        expect(bufferStruct.isDirty()).to.equal(true);
+        expect(bufferStruct.isDirty(0)).to.equal(true);
+        expect(bufferStruct.isDirty(1)).to.equal(true);
+        expect(bufferStruct.isDirty(2)).to.equal(false);
+        expect(bufferStruct.isDirty(3)).to.equal(false);
+        expect(bufferStruct.isDirty(4)).to.equal(false);
+        expect(bufferStruct.isDirty(5)).to.equal(false);
+      });
+
+      it('isDirty() should indicate if any or a specific property was changed (extended)', () => {
+        const bufferStruct = new ExtTestBufferStruct();
+        expect(bufferStruct.isDirty()).to.equal(false);
+        expect(bufferStruct.isDirty(0)).to.equal(false); // numProp1
+        expect(bufferStruct.isDirty(1)).to.equal(false); // stringProp1
+        expect(bufferStruct.isDirty(2)).to.equal(false); // booleanProp1
+        expect(bufferStruct.isDirty(3)).to.equal(false); // numProp2
+        expect(bufferStruct.isDirty(4)).to.equal(false); // stringProp2
+        expect(bufferStruct.isDirty(5)).to.equal(false); // booleanProp2
+        expect(bufferStruct.isDirty(6)).to.equal(false); // extBooleanProp1
+        expect(bufferStruct.isDirty(7)).to.equal(false); // extNumProp1
+        expect(bufferStruct.isDirty(8)).to.equal(false); // extStringProp1
+        bufferStruct.numProp1 = 123;
+        expect(bufferStruct.isDirty()).to.equal(true);
+        expect(bufferStruct.isDirty(0)).to.equal(true);
+        expect(bufferStruct.isDirty(1)).to.equal(false);
+        expect(bufferStruct.isDirty(2)).to.equal(false);
+        expect(bufferStruct.isDirty(3)).to.equal(false);
+        expect(bufferStruct.isDirty(4)).to.equal(false);
+        expect(bufferStruct.isDirty(5)).to.equal(false);
+        expect(bufferStruct.isDirty(6)).to.equal(false);
+        expect(bufferStruct.isDirty(7)).to.equal(false);
+        expect(bufferStruct.isDirty(8)).to.equal(false);
         bufferStruct.extStringProp1 = 'abc';
         expect(bufferStruct.isDirty()).to.equal(true);
         expect(bufferStruct.isDirty(0)).to.equal(true);
@@ -410,19 +495,25 @@ describe('BufferStruct', function () {
         expect(bufferStruct.isDirty(2)).to.equal(false);
         expect(bufferStruct.isDirty(3)).to.equal(false);
         expect(bufferStruct.isDirty(4)).to.equal(false);
-        expect(bufferStruct.isDirty(5)).to.equal(true);
+        expect(bufferStruct.isDirty(5)).to.equal(false);
+        expect(bufferStruct.isDirty(6)).to.equal(false);
+        expect(bufferStruct.isDirty(7)).to.equal(false);
+        expect(bufferStruct.isDirty(8)).to.equal(true);
       });
 
       it('resetDirty() should reset the dirty bits', () => {
         const bufferStruct = new TestBufferStruct();
         bufferStruct.numProp1 = 123;
         bufferStruct.stringProp1 = 'abc';
+        bufferStruct.booleanProp2 = true;
         bufferStruct.resetDirty();
         expect(bufferStruct.isDirty()).to.equal(false);
         expect(bufferStruct.isDirty(0)).to.equal(false); // numProp1
         expect(bufferStruct.isDirty(1)).to.equal(false); // stringProp1
-        expect(bufferStruct.isDirty(2)).to.equal(false); // numProp2
-        expect(bufferStruct.isDirty(3)).to.equal(false); // stringProp2
+        expect(bufferStruct.isDirty(2)).to.equal(false); // booleanProp1
+        expect(bufferStruct.isDirty(3)).to.equal(false); // numProp2
+        expect(bufferStruct.isDirty(4)).to.equal(false); // stringProp2
+        expect(bufferStruct.isDirty(5)).to.equal(false); // booleanProp2
       });
     });
 

--- a/browser-tests/buffer-structs/ExtTestBufferStruct.ts
+++ b/browser-tests/buffer-structs/ExtTestBufferStruct.ts
@@ -23,6 +23,7 @@ import {
 
 export interface ExtTestBufferStructWritableProps
   extends TestBufferStructWritableProps {
+  extBooleanProp1: boolean;
   extNumProp1: number;
   extStringProp1: string;
 }
@@ -32,6 +33,15 @@ export class ExtTestBufferStruct
   implements ExtTestBufferStructWritableProps
 {
   static override typeId = genTypeId('EXTT');
+
+  @structProp('boolean')
+  get extBooleanProp1(): boolean {
+    return false;
+  }
+
+  set extBooleanProp1(v: boolean) {
+    // Provided by decorator
+  }
 
   @structProp('number')
   get extNumProp1(): number {

--- a/browser-tests/buffer-structs/TestBufferStruct.ts
+++ b/browser-tests/buffer-structs/TestBufferStruct.ts
@@ -20,8 +20,10 @@ import { BufferStruct, genTypeId, structProp } from '@lightningjs/threadx';
 export interface TestBufferStructWritableProps {
   numProp1: number;
   stringProp1: string;
+  booleanProp1: boolean;
   numProp2: number;
   stringProp2: string;
+  booleanProp2: boolean;
 }
 
 export class TestBufferStruct
@@ -48,6 +50,15 @@ export class TestBufferStruct
     // Provided by decorator
   }
 
+  @structProp('boolean')
+  get booleanProp1(): boolean {
+    return false;
+  }
+
+  set booleanProp1(v: boolean) {
+    // Provided by decorator
+  }
+
   @structProp('number')
   get numProp2(): number {
     return 0;
@@ -63,6 +74,15 @@ export class TestBufferStruct
   }
 
   set stringProp2(v: string) {
+    // Provided by decorator
+  }
+
+  @structProp('boolean')
+  get booleanProp2(): boolean {
+    return false;
+  }
+
+  set booleanProp2(v: boolean) {
     // Provided by decorator
   }
 }

--- a/browser-tests/shared-objects/ExtTestSharedObject.ts
+++ b/browser-tests/shared-objects/ExtTestSharedObject.ts
@@ -30,11 +30,13 @@ export class ExtTestSharedObject
 
   constructor(extBufferStruct: ExtTestBufferStruct, isWorker?: boolean) {
     super(extBufferStruct, isWorker, {
+      extBooleanProp1: extBufferStruct.extBooleanProp1,
       extNumProp1: extBufferStruct.extNumProp1,
       extStringProp1: extBufferStruct.extStringProp1,
     } satisfies Omit<ExtTestBufferStructWritableProps, keyof TestBufferStructWritableProps>);
   }
 
+  declare extBooleanProp1: boolean;
   declare extNumProp1: number;
   declare extStringProp1: string;
 }

--- a/browser-tests/shared-objects/TestSharedObject.ts
+++ b/browser-tests/shared-objects/TestSharedObject.ts
@@ -36,8 +36,10 @@ export class TestSharedObject
       ...extendedCurProps,
       numProp1: sharedNodeStruct.numProp1,
       stringProp1: sharedNodeStruct.stringProp1,
+      booleanProp1: sharedNodeStruct.booleanProp1,
       numProp2: sharedNodeStruct.numProp2,
       stringProp2: sharedNodeStruct.stringProp2,
+      booleanProp2: sharedNodeStruct.booleanProp2,
     });
     if (isWorker) {
       this.on('ping', (target, event) => {
@@ -52,8 +54,10 @@ export class TestSharedObject
 
   declare numProp1: number;
   declare stringProp1: string;
+  declare booleanProp1: boolean;
   declare numProp2: number;
   declare stringProp2: string;
+  declare booleanProp2: boolean;
 
   exposedOnDestroy() {
     // Exposed to allow testing of onDestroy() method

--- a/src/BufferStruct.ts
+++ b/src/BufferStruct.ts
@@ -123,7 +123,8 @@ export function structProp(type: StructPropType, options?: StructPropOptions) {
     };
     propDefs.push(propDef);
 
-    constructor.size += byteSize;
+    // console.log(constructor.size, byteOffset, byteSize, propDef);
+    constructor.size = byteOffset + byteSize;
 
     // TODO: Move the descriptors to the prototype to avoid code duplication/closures
     descriptor.get = function (this: BufferStruct) {


### PR DESCRIPTION
Proper word alignment was not maintained when boolean props were used causing values in a BufferStruct to get corrupted.

Tests updated and passed.