### PR TITLE
Include `src` files for SourceMaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "files": [
     "dist",
+    "src",
     "LICENSE",
     "NOTICE",
     "README.md"


### PR DESCRIPTION
- Fixes a Vite error that users of ThreadX experienced