### PR TITLE
Added globalThis to resolvedGlobal when self doesn't exist.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,7 @@
     "": {
       "name": "@lightningjs/threadx",
       "version": "0.3.3",
-      "dev": true,
-      "license": "ISC",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@lightningjs/threadx": "file:",
         "@types/mocha": "^10.0.1",
@@ -8574,7 +8573,7 @@
         "prettier": "^2.8.7",
         "tap-diff": "^0.1.1",
         "tape": "^5.6.1",
-        "typedoc": "*",
+        "typedoc": "^0.25.1",
         "typescript": "^5.0.3",
         "vite": "^4.0.4",
         "vite-plugin-mkcert": "^1.13.3",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,8 @@
  * In the future we may try to get ThreadX working with NodeJS, in that case
  * this can be changed to include NodeJS vs Browser detection logic.
  */
-export const resolvedGlobal = self;
+export const resolvedGlobal: any =
+  typeof self === 'undefined' ? globalThis : self;
 
 export function assertTruthy(
   condition: unknown,


### PR DESCRIPTION
This prevents errors in runtimes where 'self' doesn't exists. For example inside a node based test runner.