### PR TITLE
Enable specific properties to allow undefined values

### DIFF
--- a/browser-tests/BufferStruct.test.ts
+++ b/browser-tests/BufferStruct.test.ts
@@ -26,7 +26,7 @@ describe('BufferStruct', function () {
   describe('static', () => {
     it('base initial state', () => {
       expect(BufferStruct.staticInitialized).to.equal(false);
-      expect(BufferStruct.size).to.equal(32);
+      expect(BufferStruct.size).to.equal(40);
       expect(BufferStruct.typeId).to.equal(0);
       expect(BufferStruct.typeIdStr).to.equal('');
       expect(BufferStruct.propDefs).to.deep.equal([]);
@@ -34,65 +34,70 @@ describe('BufferStruct', function () {
 
     it('sub-class initial state', () => {
       expect(TestBufferStruct.staticInitialized).to.equal(true);
-      expect(TestBufferStruct.size).to.equal(1084);
+      expect(TestBufferStruct.size).to.equal(1092);
       expect(TestBufferStruct.typeId).to.equal(genTypeId('TEST'));
       expect(TestBufferStruct.typeIdStr).to.equal('TEST');
-      console.log(TestBufferStruct.propDefs);
       expect(TestBufferStruct.propDefs).to.deep.equal([
         {
           propNum: 0,
           name: 'numProp1',
           type: 'number',
-          byteOffset: 32,
-          offset: 4,
+          byteOffset: 40,
+          offset: 5,
           byteSize: 8,
+          allowUndefined: false,
         },
         {
           propNum: 1,
           name: 'stringProp1',
           type: 'string',
-          byteOffset: 40,
-          offset: 20,
+          byteOffset: 48,
+          offset: 24,
           byteSize: 512,
+          allowUndefined: false,
         },
         {
           propNum: 2,
           name: 'booleanProp1',
           type: 'boolean',
-          byteOffset: 552,
-          offset: 138,
+          byteOffset: 560,
+          offset: 140,
           byteSize: 4,
+          allowUndefined: false,
         },
         {
           propNum: 3,
           name: 'numProp2',
           type: 'number',
-          byteOffset: 560,
-          offset: 70,
+          byteOffset: 568,
+          offset: 71,
           byteSize: 8,
+          allowUndefined: true,
         },
         {
           propNum: 4,
           name: 'stringProp2',
           type: 'string',
-          byteOffset: 568,
-          offset: 284,
+          byteOffset: 576,
+          offset: 288,
           byteSize: 512,
+          allowUndefined: true,
         },
         {
           propNum: 5,
           name: 'booleanProp2',
           type: 'boolean',
-          byteOffset: 1080,
-          offset: 270,
+          byteOffset: 1088,
+          offset: 272,
           byteSize: 4,
+          allowUndefined: true,
         },
       ]);
     });
 
     it('extended sub-class initial state', () => {
       expect(ExtTestBufferStruct.staticInitialized).to.equal(true);
-      expect(ExtTestBufferStruct.size).to.equal(1608);
+      expect(ExtTestBufferStruct.size).to.equal(1620);
       expect(ExtTestBufferStruct.typeId).to.equal(genTypeId('EXTT'));
       expect(ExtTestBufferStruct.typeIdStr).to.equal('EXTT');
       expect(ExtTestBufferStruct.propDefs).to.deep.equal([
@@ -100,73 +105,91 @@ describe('BufferStruct', function () {
           propNum: 0,
           name: 'numProp1',
           type: 'number',
-          byteOffset: 32,
-          offset: 4,
+          byteOffset: 40,
+          offset: 5,
           byteSize: 8,
+          allowUndefined: false,
         },
         {
           propNum: 1,
           name: 'stringProp1',
           type: 'string',
-          byteOffset: 40,
-          offset: 20,
+          byteOffset: 48,
+          offset: 24,
           byteSize: 512,
+          allowUndefined: false,
         },
         {
           propNum: 2,
           name: 'booleanProp1',
           type: 'boolean',
-          byteOffset: 552,
-          offset: 138,
+          byteOffset: 560,
+          offset: 140,
           byteSize: 4,
+          allowUndefined: false,
         },
         {
           propNum: 3,
           name: 'numProp2',
           type: 'number',
-          byteOffset: 560,
-          offset: 70,
+          byteOffset: 568,
+          offset: 71,
           byteSize: 8,
+          allowUndefined: true,
         },
         {
           propNum: 4,
           name: 'stringProp2',
           type: 'string',
-          byteOffset: 568,
-          offset: 284,
+          byteOffset: 576,
+          offset: 288,
           byteSize: 512,
+          allowUndefined: true,
         },
         {
           propNum: 5,
           name: 'booleanProp2',
           type: 'boolean',
-          byteOffset: 1080,
-          offset: 270,
+          byteOffset: 1088,
+          offset: 272,
           byteSize: 4,
+          allowUndefined: true,
         },
         {
           propNum: 6,
           name: 'extBooleanProp1',
           type: 'boolean',
-          byteOffset: 1084,
-          offset: 271,
+          byteOffset: 1092,
+          offset: 273,
           byteSize: 4,
+          allowUndefined: true,
         },
         {
           propNum: 7,
           name: 'extNumProp1',
           type: 'number',
-          byteOffset: 1088,
-          offset: 136,
+          byteOffset: 1096,
+          offset: 137,
           byteSize: 8,
+          allowUndefined: false,
         },
         {
           propNum: 8,
           name: 'extStringProp1',
           type: 'string',
-          byteOffset: 1096,
-          offset: 548,
+          byteOffset: 1104,
+          offset: 552,
           byteSize: 512,
+          allowUndefined: false,
+        },
+        {
+          propNum: 9,
+          name: 'extBooleanProp2',
+          type: 'boolean',
+          byteOffset: 1616,
+          offset: 404,
+          byteSize: 4,
+          allowUndefined: true,
         },
       ]);
     });
@@ -245,22 +268,29 @@ describe('BufferStruct', function () {
         const bufferStruct = new TestBufferStruct();
         // Number
         expect(bufferStruct.numProp1).to.equal(0);
-        expect(bufferStruct.numProp2).to.equal(0);
+        expect(bufferStruct.numProp2).to.equal(undefined);
         // String
         expect(bufferStruct.stringProp1).to.equal('');
-        expect(bufferStruct.stringProp2).to.equal('');
+        expect(bufferStruct.stringProp2).to.equal(undefined);
+        // Boolean
+        expect(bufferStruct.booleanProp1).to.equal(false);
+        expect(bufferStruct.booleanProp2).to.equal(undefined);
       });
 
       it('should create instance with default empty values (extended)', () => {
         const bufferStruct = new ExtTestBufferStruct();
         // Number
         expect(bufferStruct.numProp1).to.equal(0);
-        expect(bufferStruct.numProp2).to.equal(0);
+        expect(bufferStruct.numProp2).to.equal(undefined);
         expect(bufferStruct.extNumProp1).to.equal(0);
         // String
         expect(bufferStruct.stringProp1).to.equal('');
-        expect(bufferStruct.stringProp2).to.equal('');
+        expect(bufferStruct.stringProp2).to.equal(undefined);
         expect(bufferStruct.extStringProp1).to.equal('');
+        // Boolean
+        expect(bufferStruct.booleanProp1).to.equal(false);
+        expect(bufferStruct.booleanProp2).to.equal(undefined);
+        expect(bufferStruct.extBooleanProp1).to.equal(undefined);
       });
 
       it('should construct instance with a cross-worker unique id', () => {
@@ -311,6 +341,71 @@ describe('BufferStruct', function () {
         expect(bufferStruct2.stringProp1).to.equal('abc');
         expect(bufferStruct2.stringProp2).to.equal('def');
         expect(bufferStruct2.extStringProp1).to.equal('ghi');
+      });
+    });
+
+    describe('allowUndefined properties', () => {
+      it('should be initialized to undefined', () => {
+        const bufferStruct = new ExtTestBufferStruct();
+        // Number
+        expect(bufferStruct.numProp2).to.equal(undefined);
+        // String
+        expect(bufferStruct.stringProp2).to.equal(undefined);
+        // Boolean
+        expect(bufferStruct.booleanProp2).to.equal(undefined);
+        expect(bufferStruct.extBooleanProp1).to.equal(undefined);
+      });
+
+      it('should set to defined values, then to undefined values and then back', () => {
+        const bufferStruct = new ExtTestBufferStruct();
+        // Set to defined
+        // Number
+        bufferStruct.numProp2 = 0;
+        expect(bufferStruct.numProp2).to.equal(0);
+        // String
+        bufferStruct.stringProp2 = '';
+        expect(bufferStruct.stringProp2).to.equal('');
+        // Boolean
+        bufferStruct.booleanProp2 = false;
+        expect(bufferStruct.booleanProp2).to.equal(false);
+
+        // Set to undefined
+        // Number
+        bufferStruct.numProp2 = undefined;
+        expect(bufferStruct.numProp2).to.equal(undefined);
+        // String
+        bufferStruct.stringProp2 = undefined;
+        expect(bufferStruct.stringProp2).to.equal(undefined);
+        // Boolean
+        bufferStruct.booleanProp2 = undefined;
+        expect(bufferStruct.booleanProp2).to.equal(undefined);
+
+        // Set back to defined
+        // Number
+        bufferStruct.numProp2 = 123;
+        expect(bufferStruct.numProp2).to.equal(123);
+        // String
+        bufferStruct.stringProp2 = 'abc';
+        expect(bufferStruct.stringProp2).to.equal('abc');
+        // Boolean
+        bufferStruct.booleanProp2 = true;
+        expect(bufferStruct.booleanProp2).to.equal(true);
+      });
+
+      it('should be able to be rehydrated from ArrayBuffer', () => {
+        const bufferStruct = new ExtTestBufferStruct();
+        // Set to defined
+        bufferStruct.numProp2 = 123;
+        bufferStruct.stringProp2 = 'abc';
+        bufferStruct.booleanProp2 = true;
+        bufferStruct.numProp2 = undefined;
+        bufferStruct.stringProp2 = undefined;
+        bufferStruct.booleanProp2 = undefined;
+
+        const bufferStruct2 = new ExtTestBufferStruct(bufferStruct.buffer);
+        expect(bufferStruct2.numProp2).to.equal(undefined);
+        expect(bufferStruct2.stringProp2).to.equal(undefined);
+        expect(bufferStruct2.booleanProp2).to.equal(undefined);
       });
     });
 
@@ -618,6 +713,11 @@ describe('BufferStruct', function () {
          * mechanism on either side.
          */
         const bufferStruct = new TestBufferStruct();
+
+        // Define the allowUndefined properties
+        bufferStruct.numProp2 = 0;
+        bufferStruct.stringProp2 = '';
+
         threadx.sendMessage('test-worker', {
           type: 'fight-for-lock',
           buffer: bufferStruct.buffer,

--- a/browser-tests/buffer-structs/ExtTestBufferStruct.ts
+++ b/browser-tests/buffer-structs/ExtTestBufferStruct.ts
@@ -23,9 +23,10 @@ import {
 
 export interface ExtTestBufferStructWritableProps
   extends TestBufferStructWritableProps {
-  extBooleanProp1: boolean;
+  extBooleanProp1?: boolean;
   extNumProp1: number;
   extStringProp1: string;
+  extBooleanProp2?: boolean;
 }
 
 export class ExtTestBufferStruct
@@ -34,12 +35,14 @@ export class ExtTestBufferStruct
 {
   static override typeId = genTypeId('EXTT');
 
-  @structProp('boolean')
-  get extBooleanProp1(): boolean {
+  @structProp('boolean', {
+    allowUndefined: true,
+  })
+  get extBooleanProp1(): boolean | undefined {
     return false;
   }
 
-  set extBooleanProp1(v: boolean) {
+  set extBooleanProp1(v: boolean | undefined) {
     // Provided by decorator
   }
 
@@ -58,6 +61,17 @@ export class ExtTestBufferStruct
   }
 
   set extStringProp1(v: string) {
+    // Provided by decorator
+  }
+
+  @structProp('boolean', {
+    allowUndefined: true,
+  })
+  get extBooleanProp2(): boolean | undefined {
+    return false;
+  }
+
+  set extBooleanProp2(v: boolean | undefined) {
     // Provided by decorator
   }
 }

--- a/browser-tests/buffer-structs/TestBufferStruct.ts
+++ b/browser-tests/buffer-structs/TestBufferStruct.ts
@@ -21,9 +21,9 @@ export interface TestBufferStructWritableProps {
   numProp1: number;
   stringProp1: string;
   booleanProp1: boolean;
-  numProp2: number;
-  stringProp2: string;
-  booleanProp2: boolean;
+  numProp2?: number;
+  stringProp2?: string;
+  booleanProp2: boolean | undefined;
 }
 
 export class TestBufferStruct
@@ -59,30 +59,36 @@ export class TestBufferStruct
     // Provided by decorator
   }
 
-  @structProp('number')
-  get numProp2(): number {
+  @structProp('number', {
+    allowUndefined: true,
+  })
+  get numProp2(): number | undefined {
     return 0;
   }
 
-  set numProp2(v: number) {
+  set numProp2(v: number | undefined) {
     // Provided by decorator
   }
 
-  @structProp('string')
-  get stringProp2(): string {
+  @structProp('string', {
+    allowUndefined: true,
+  })
+  get stringProp2(): string | undefined {
     return '';
   }
 
-  set stringProp2(v: string) {
+  set stringProp2(v: string | undefined) {
     // Provided by decorator
   }
 
-  @structProp('boolean')
-  get booleanProp2(): boolean {
+  @structProp('boolean', {
+    allowUndefined: true,
+  })
+  get booleanProp2(): boolean | undefined {
     return false;
   }
 
-  set booleanProp2(v: boolean) {
+  set booleanProp2(v: boolean | undefined) {
     // Provided by decorator
   }
 }

--- a/browser-tests/shared-objects/ExtTestSharedObject.ts
+++ b/browser-tests/shared-objects/ExtTestSharedObject.ts
@@ -33,10 +33,12 @@ export class ExtTestSharedObject
       extBooleanProp1: extBufferStruct.extBooleanProp1,
       extNumProp1: extBufferStruct.extNumProp1,
       extStringProp1: extBufferStruct.extStringProp1,
+      extBooleanProp2: extBufferStruct.extBooleanProp2,
     } satisfies Omit<ExtTestBufferStructWritableProps, keyof TestBufferStructWritableProps>);
   }
 
-  declare extBooleanProp1: boolean;
+  declare extBooleanProp1: boolean | undefined;
   declare extNumProp1: number;
   declare extStringProp1: string;
+  declare extBooleanProp2: boolean | undefined;
 }

--- a/browser-tests/shared-objects/TestSharedObject.ts
+++ b/browser-tests/shared-objects/TestSharedObject.ts
@@ -55,9 +55,9 @@ export class TestSharedObject
   declare numProp1: number;
   declare stringProp1: string;
   declare booleanProp1: boolean;
-  declare numProp2: number;
-  declare stringProp2: string;
-  declare booleanProp2: boolean;
+  declare numProp2?: number;
+  declare stringProp2?: string;
+  declare booleanProp2: boolean | undefined;
 
   exposedOnDestroy() {
     // Exposed to allow testing of onDestroy() method

--- a/browser-tests/threadx.test.ts
+++ b/browser-tests/threadx.test.ts
@@ -288,16 +288,20 @@ describe('ThreadX', function () {
           expect(result1.properties).to.deep.equal({
             numProp1: 0,
             stringProp1: '',
-            numProp2: 0,
-            stringProp2: '',
+            booleanProp1: false,
+            numProp2: undefined,
+            stringProp2: undefined,
+            booleanProp2: undefined,
           });
           expect(result2.objectKnownByThreadX).to.equal(true);
           expect(result2.isInstanceOfTestSharedObject).to.equal(true);
           expect(result2.properties).to.deep.equal({
             numProp1: 0,
             stringProp1: '',
-            numProp2: 0,
-            stringProp2: '',
+            booleanProp1: false,
+            numProp2: undefined,
+            stringProp2: undefined,
+            booleanProp2: undefined,
           });
         });
       });

--- a/browser-tests/workers/TestWorker.ts
+++ b/browser-tests/workers/TestWorker.ts
@@ -111,14 +111,17 @@ const threadX = ThreadX.init({
         };
       }
       sharedObjectStash.set(objectId, sharedObject);
+
       return {
         objectKnownByThreadX: true,
         isInstanceOfTestSharedObject: true,
         properties: {
           numProp1: sharedObject.numProp1,
           stringProp1: sharedObject.stringProp1,
+          booleanProp1: sharedObject.booleanProp1,
           numProp2: sharedObject.numProp2,
           stringProp2: sharedObject.stringProp2,
+          booleanProp2: sharedObject.booleanProp2,
         },
       };
     } else if (message.type === 'shared-object-synchronize-test') {
@@ -126,7 +129,7 @@ const threadX = ThreadX.init({
       const raceNotifyBuffer = message.raceNotifyBuffer as SharedArrayBuffer;
       const raceNotify = new Int32Array(raceNotifyBuffer);
       const sharedObject = threadX.getSharedObjectById(objectId);
-      assertTruthy(sharedObject instanceof TestSharedObject);
+      assertTruthy(sharedObject instanceof ExtTestSharedObject);
       // Tell the parent worker that we're ready to start fightning for the
       // lock
       Atomics.store(raceNotify, 0, 1);
@@ -151,6 +154,8 @@ const threadX = ThreadX.init({
         sharedObject.numProp2 = 2;
         sharedObject.stringProp1 = 'two';
         sharedObject.stringProp2 = 'two';
+        sharedObject.extBooleanProp1 = undefined;
+        sharedObject.extBooleanProp2 = undefined;
         await delay(0);
       }
       return {


### PR DESCRIPTION
Properties on `BufferStructs` can now be declared to `allowUndefined` values. When enabled, the property will default to undefined and can be set to a defined value or an undefined value. There is no change to behavior when the `allowUndefined` flag is not set.

Required for the implementation of:
- https://github.com/lightning-js/renderer/issues/170